### PR TITLE
Apply new configuration format

### DIFF
--- a/commands/collections/create.js
+++ b/commands/collections/create.js
@@ -12,32 +12,23 @@ const validate = require('./validate');
 const connectWithCreate = require('../../modules/connectWithCreate');
 const writeResponseError = require('../../modules/writeResponseError');
 
-function createTableFromSchema (collectionName, fields, connection, callback) {
-  const idField = 'id VARCHAR (36) PRIMARY KEY NOT NULL UNIQUE';
-
+function createTableFromSchema (collectionName, connection, callback) {
   sqlite.run(
-    `CREATE TABLE "${collectionName}" (${idField} ${fields ? ', ' + fields : ''})`,
+    `CREATE TABLE "_${collectionName}" (
+      id VARCHAR (36) PRIMARY KEY NOT NULL UNIQUE,
+      data TEXT,
+      date_created NUMBER
+    )`,
     connection, callback
   );
-}
-
-function createFieldsFromSchema (schema, callback) {
-  const fields = Object.keys(schema || [])
-    .map(fieldKey => {
-      return `${fieldKey} TEXT`;
-    })
-    .join(', ');
-
-  callback(null, fields);
 }
 
 function createCollectionDatabase (databasePath, databaseName, collectionConfig, callback) {
   const collectionName = collectionConfig.name;
   const filePath = path.resolve(databasePath, `${databaseName}/${collectionName}.db`);
-  const fields = righto(createFieldsFromSchema, collectionConfig.schema);
 
   const dbConnection = righto(connectWithCreate, filePath);
-  const createdTable = righto(createTableFromSchema, collectionName, fields, dbConnection);
+  const createdTable = righto(createTableFromSchema, collectionName, dbConnection);
   const closedDatabase = righto(sqlite.close, dbConnection, righto.after(createdTable));
 
   closedDatabase(function (error) {

--- a/commands/collections/validate.js
+++ b/commands/collections/validate.js
@@ -4,7 +4,6 @@ const validateAlphaNumericDash = require('../../modules/validations/validateAlph
 const validateKeyIsAlphaNumericDash = require('../../modules/validations/validateKeyIsAlphaNumericDash');
 const validateObjectProperties = require('../../modules/validations/validateObjectProperties');
 const validateArrayOfStrings = require('../../modules/validations/validateArrayOfStrings');
-const validateKeyInList = require('../../modules/validations/validateKeyInList');
 const validateRequired = require('../../modules/validations/validateRequired');
 
 function validate (data, callback) {

--- a/commands/records/create.js
+++ b/commands/records/create.js
@@ -1,6 +1,5 @@
 const righto = require('righto');
 const sqlite = require('sqlite-fp');
-const ErrorWithObject = require('error-with-object');
 const finalStream = require('final-stream');
 const writeResponse = require('write-response');
 
@@ -9,114 +8,10 @@ const getCollection = require('../../modules/getCollection');
 const getUser = require('../../modules/getUser');
 const applyPresentersToData = require('../../modules/applyPresentersToData');
 const applyTransducersToData = require('../../modules/applyTransducersToData');
-const evaluate = require('../../modules/evaluate');
 const writeResponseError = require('../../modules/writeResponseError');
+const validateDataAgainstSchema = require('../../modules/validateDataAgainstSchema');
 
 const uuidv4 = require('uuid').v4;
-
-function checkFieldValidation (schema, field, scope, callback) {
-  if (!schema[field]) {
-    return callback(null, { [field]: 'unknown column' });
-  }
-
-  const fieldValidations = schema[field].map(checkFn => {
-    if (checkFn === 'required') {
-      return;
-    }
-
-    if (checkFn === 'string') {
-      checkFn = 'value == null || getType(value) == "string" ? null : "must be string"';
-    }
-
-    if (checkFn === 'number') {
-      checkFn = 'value == null || getType(value) == "number" ? null : "must be number"';
-    }
-
-    if (checkFn === 'array') {
-      checkFn = 'value == null || getType(value) == "Array" ? null : "must be array"';
-    }
-
-    return righto(evaluate, checkFn, {
-      ...scope,
-      field,
-      value: scope.body[field]
-    });
-  });
-
-  righto.all(fieldValidations)(function (error, fieldResult) {
-    if (error) { return callback(error); }
-
-    const errors = fieldResult.reduce((accumulator, invalid) => {
-      if (invalid) {
-        accumulator[field] = accumulator[field] || [];
-        accumulator[field].push(invalid);
-      }
-      return accumulator;
-    }, {});
-
-    callback(null, errors);
-  });
-}
-
-function checkSchemaValidations (schema, scope, errors, callback) {
-  if (!schema) {
-    return callback();
-  }
-
-  const schemaValidations = Object.keys(scope.body)
-    .map(field => {
-      return righto(checkFieldValidation, schema, field, scope);
-    });
-
-  righto.all(schemaValidations)(function (error, results) {
-    if (error) { return callback(error); }
-
-    results.forEach(validationError => {
-      errors = Object.assign(errors, validationError);
-    });
-
-    if (Object.keys(errors).length > 0) {
-      return callback(new ErrorWithObject({
-        statusCode: 400,
-        friendly: errors
-      }));
-    }
-    callback();
-  });
-}
-
-function validateDataAgainstSchema (collectionConfig, scope, callback) {
-  const { schema } = collectionConfig;
-
-  if (!schema) {
-    return callback(null, scope.body);
-  }
-
-  const errors = {};
-
-  if (schema) {
-    // TODO: Abstract checkForRequiredFields()
-    Object.keys(schema).forEach(field => {
-      if (schema[field].includes('required') && !scope.body[field]) {
-        errors[field] = errors[field] || [];
-        errors[field].push('required');
-      }
-    });
-
-    // TODO: Abstract checkForUnknownFields()
-    Object.keys(scope.body).map(field => {
-      if (!schema[field]) {
-        errors[field] = errors[field] || [];
-        errors[field].push('unknown field');
-      }
-    });
-  }
-
-  const schemaValidated = righto(checkSchemaValidations, schema, scope, errors);
-  const result = righto.mate(scope.body, righto.after(schemaValidated));
-
-  result(callback);
-}
 
 function insertRecordIntoDatabase (collectionId, data, dbConnection, callback) {
   if (typeof data !== 'object') {

--- a/commands/records/create.js
+++ b/commands/records/create.js
@@ -88,11 +88,8 @@ function checkSchemaValidations (schema, scope, errors, callback) {
 function validateDataAgainstSchema (collectionConfig, scope, callback) {
   const { schema } = collectionConfig;
 
-  if (!schema || schema.length === 0) {
-    return callback(new ErrorWithObject({
-      statusCode: 400,
-      friendly: 'collection has no fields so you can not post'
-    }));
+  if (!schema) {
+    return callback(null, scope.body);
   }
 
   const errors = {};

--- a/modules/applyPresentersToData.js
+++ b/modules/applyPresentersToData.js
@@ -29,12 +29,15 @@ function transformArraysProperty (schema, record) {
     }, {});
 }
 
-function presentDataSingle (collectionConfig, record, user, headers, callback) {
+function presentDataSingle (collectionConfig, scope, record, callback) {
   const { presenters } = collectionConfig;
 
   const presenterFunctions = (presenters || [])
     .map(presenter => {
-      return righto(evaluate, presenter, { record, user, headers });
+      return righto(evaluate, presenter, {
+        ...scope,
+        record
+      });
     });
 
   righto.all(presenterFunctions)(function (error, presenters) {
@@ -51,16 +54,16 @@ function presentDataSingle (collectionConfig, record, user, headers, callback) {
   });
 }
 
-function applyPresentersToData (collectionConfig, record, user, headers, callback) {
-  if (Array.isArray(record)) {
-    const presenterJobs = record.map(record => {
-      return righto(presentDataSingle, collectionConfig, record, user, headers);
+function applyPresentersToData (collectionConfig, scope, callback) {
+  if (Array.isArray(scope.record)) {
+    const presenterJobs = scope.record.map(record => {
+      return righto(presentDataSingle, collectionConfig, scope, record);
     });
 
     return righto.all(presenterJobs)(callback);
   }
 
-  presentDataSingle(collectionConfig, record, user, headers, callback);
+  presentDataSingle(collectionConfig, scope, scope.record, callback);
 }
 
 module.exports = applyPresentersToData;

--- a/modules/applyPresentersToData.js
+++ b/modules/applyPresentersToData.js
@@ -2,7 +2,7 @@ const righto = require('righto');
 const evaluate = require('./evaluate');
 
 function transformArraysProperty (schema, record) {
-  if (!record) {
+  if (!schema) {
     return record;
   }
 
@@ -50,6 +50,7 @@ function presentDataSingle (collectionConfig, scope, record, callback) {
     });
 
     record = transformArraysProperty(collectionConfig.schema, record);
+
     callback(null, record);
   });
 }

--- a/modules/applyTransducersToData.js
+++ b/modules/applyTransducersToData.js
@@ -20,13 +20,11 @@ function applyTransducersToData (collectionConfig, scope, callback) {
   const finalBody = righto.reduce(
     transducers,
     function (body, next) {
-      const evaulatedResult = righto(evaluate, next, {
+      return righto(evaluate, next, {
         ...scope,
         reject,
         body
-      });
-
-      return evaulatedResult;
+      }).get(result => typeof result === 'object' ? result : righto.fail('Must return an object'));
     },
     scope.body
   );

--- a/modules/getUser.js
+++ b/modules/getUser.js
@@ -6,7 +6,7 @@ const ErrorWithObject = require('error-with-object');
 const returnUserResult = (password, callback) => (error, user) => {
   if (error) { return callback(error); }
 
-  user = user[0];
+  user = JSON.parse(user[0].data);
 
   verifyHash(password, user.password, function (error, passwordMatched) {
     if (error) {
@@ -24,7 +24,7 @@ const returnUserResult = (password, callback) => (error, user) => {
 module.exports = config => function (db, username, password, callback) {
   // Get user if logged in
   if (username && password) {
-    sqlite.getAll('SELECT * FROM users WHERE username = ?', [username], db, returnUserResult(password, callback));
+    sqlite.getAll('SELECT * FROM "_users" WHERE json_extract(data, "$.username") = ?', [username], db, returnUserResult(password, callback));
   } else {
     callback(null, null);
   }

--- a/modules/validateDataAgainstSchema.js
+++ b/modules/validateDataAgainstSchema.js
@@ -1,0 +1,114 @@
+const righto = require('righto');
+const ErrorWithObject = require('error-with-object');
+
+const evaluate = require('./evaluate');
+
+function checkFieldValidation (schema, field, scope, callback) {
+  if (!schema[field]) {
+    return callback(null, { [field]: 'unknown column' });
+  }
+
+  const fieldValidations = schema[field].map(checkFn => {
+    if (checkFn === 'required') {
+      return;
+    }
+
+    if (checkFn === 'string') {
+      checkFn = 'value == null || getType(value) == "string" ? null : "must be string"';
+    }
+
+    if (checkFn === 'number') {
+      checkFn = 'value == null || getType(value) == "number" ? null : "must be number"';
+    }
+
+    if (checkFn === 'array') {
+      checkFn = 'value == null || getType(value) == "Array" ? null : "must be array"';
+    }
+
+    return righto(evaluate, checkFn, {
+      ...scope,
+      field,
+      value: scope.body[field]
+    });
+  });
+
+  righto.all(fieldValidations)(function (error, fieldResult) {
+    if (error) { return callback(error); }
+
+    const errors = fieldResult.reduce((accumulator, invalid) => {
+      if (invalid) {
+        accumulator[field] = accumulator[field] || [];
+        accumulator[field].push(invalid);
+      }
+      return accumulator;
+    }, {});
+
+    callback(null, errors);
+  });
+}
+
+function checkSchemaValidations (schema, scope, errors, callback) {
+  if (!schema) {
+    return callback();
+  }
+
+  const schemaValidations = Object.keys(scope.body)
+    .map(field => {
+      return righto(checkFieldValidation, schema, field, scope);
+    });
+
+  righto.all(schemaValidations)(function (error, results) {
+    if (error) { return callback(error); }
+
+    results.forEach(validationError => {
+      errors = Object.assign(errors, validationError);
+    });
+
+    if (Object.keys(errors).length > 0) {
+      return callback(new ErrorWithObject({
+        statusCode: 400,
+        friendly: errors
+      }));
+    }
+    callback();
+  });
+}
+
+function validateDataAgainstSchema (collectionConfig, scope, callback) {
+  if (!collectionConfig) {
+    throw new Error('validateDataAgainstSchema must be called with a collectionConfig');
+  }
+
+  const { schema } = collectionConfig;
+
+  if (!schema) {
+    return callback(null, scope.body);
+  }
+
+  const errors = {};
+
+  if (schema) {
+    // TODO: Abstract checkForRequiredFields()
+    Object.keys(schema).forEach(field => {
+      if (schema[field].includes('required') && !scope.body[field]) {
+        errors[field] = errors[field] || [];
+        errors[field].push('required');
+      }
+    });
+
+    // TODO: Abstract checkForUnknownFields()
+    Object.keys(scope.body).map(field => {
+      if (!schema[field]) {
+        errors[field] = errors[field] || [];
+        errors[field].push('unknown field');
+      }
+    });
+  }
+
+  const schemaValidated = righto(checkSchemaValidations, schema, scope, errors);
+  const result = righto.mate(scope.body, righto.after(schemaValidated));
+
+  result(callback);
+}
+
+module.exports = validateDataAgainstSchema;

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 require('./modules/queryStringToSql.js');
+require('./modules/applyTransducersToData.js');
 
 require('./authentication.js');
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,14 @@
-require('./modules/queryStringToSql.js');
-require('./modules/applyTransducersToData.js');
+require('./modules/queryStringToSql');
+require('./modules/validateDataAgainstSchema');
+require('./modules/applyTransducersToData');
 
-require('./authentication.js');
+require('./authentication');
 
-require('./collections/create.js');
-require('./collections/read.js');
-require('./collections/update.js');
-require('./collections/search.js');
+require('./collections/create');
+require('./collections/read');
+require('./collections/update');
+require('./collections/search');
 
-require('./records/create.js');
-require('./records/read.js');
-require('./records/search.js');
+require('./records/create');
+require('./records/read');
+require('./records/search');

--- a/test/modules/applyTransducersToData.js
+++ b/test/modules/applyTransducersToData.js
@@ -1,0 +1,39 @@
+const test = require('tape');
+const applyTransducersToData = require('../../modules/applyTransducersToData');
+
+test('applyTransducersToData -> with no transducers', (t) => {
+  t.plan(2);
+
+  function done (error, result) {
+    t.notOk(error);
+    t.ok(result);
+  }
+
+  applyTransducersToData({}, {
+    body: {
+      a: 1
+    }
+  }, done);
+});
+
+test('applyTransducersToData - ordered', (t) => {
+  t.plan(2);
+
+  function done (error, result) {
+    t.notOk(error);
+    t.equal(result.a, 16);
+  }
+
+  applyTransducersToData({
+    transducers: [
+      '{...body a: body.a + 5}',
+      '{...body a: body.a + 5}',
+      '{...body a: body.a + 5}'
+    ]
+  }, {
+    headers: {},
+    body: {
+      a: 1
+    }
+  }, done);
+});

--- a/test/modules/applyTransducersToData.js
+++ b/test/modules/applyTransducersToData.js
@@ -16,7 +16,7 @@ test('applyTransducersToData -> with no transducers', (t) => {
   }, done);
 });
 
-test('applyTransducersToData - ordered', (t) => {
+test('applyTransducersToData -> ordered', (t) => {
   t.plan(2);
 
   function done (error, result) {
@@ -29,6 +29,46 @@ test('applyTransducersToData - ordered', (t) => {
       '{...body a: body.a + 5}',
       '{...body a: body.a + 5}',
       '{...body a: body.a + 5}'
+    ]
+  }, {
+    headers: {},
+    body: {
+      a: 1
+    }
+  }, done);
+});
+
+test('applyTransducersToData -> syntax error', (t) => {
+  t.plan(2);
+
+  function done (error, result) {
+    t.equal(error.toString(), 'Parse error,\nunexpected token.,\nAt 13 "{......WHOOPS-->.<--.}"');
+    t.notOk(result, 'result was not passed');
+  }
+
+  applyTransducersToData({
+    transducers: [
+      '{......WHOOPS..}'
+    ]
+  }, {
+    headers: {},
+    body: {
+      a: 1
+    }
+  }, done);
+});
+
+test('applyTransducersToData -> returns none object', (t) => {
+  t.plan(2);
+
+  function done (error, result) {
+    t.equal(error.toString(), 'Must return an object');
+    t.notOk(result, 'result was not passed');
+  }
+
+  applyTransducersToData({
+    transducers: [
+      '"Hello there"'
     ]
   }, {
     headers: {},

--- a/test/modules/queryStringToSql.js
+++ b/test/modules/queryStringToSql.js
@@ -12,7 +12,7 @@ test('simple query', t => {
   });
 
   const sql = queryStringToSql.records('users', url.toString());
-  t.equal(sql.query, 'select "users".* from "users" where "users"."firstName" = $1 limit $2');
+  t.equal(sql.query, 'select "_users".* from "_users" where json_extract(data, "$.firstName") = $1 limit $2');
   t.deepEqual(sql.values, ['Joe', 10]);
 });
 
@@ -25,7 +25,7 @@ test('simple count query', t => {
   });
 
   const sql = queryStringToSql.count('users', url.toString());
-  t.equal(sql.query, 'select count(*) from "users" where "users"."firstName" = $1');
+  t.equal(sql.query, 'select count(*) from "_users" where json_extract(data, "$.firstName") = $1');
   t.deepEqual(sql.values, ['Joe']);
 });
 
@@ -40,6 +40,6 @@ test('danger', t => {
   });
 
   const sql = queryStringToSql.records('users', url.toString());
-  t.equal(sql.query, 'select "users".* from "users" where "users"."firstName = a" = $1 limit $2');
+  t.equal(sql.query, 'select "_users".* from "_users" where json_extract(data, "$.firstName = a") = $1 limit $2');
   t.deepEqual(sql.values, ['Joe', 10]);
 });

--- a/test/modules/validateDataAgainstSchema.js
+++ b/test/modules/validateDataAgainstSchema.js
@@ -1,0 +1,58 @@
+const test = require('tape');
+const validateDataAgainstSchema = require('../../modules/validateDataAgainstSchema');
+
+test('validateDataAgainstSchema -> with no schema', (t) => {
+  t.plan(2);
+
+  function done (error, result) {
+    t.notOk(error);
+    t.ok(result);
+  }
+
+  // schema, field, scope
+  validateDataAgainstSchema({}, {
+    body: {
+      a: 1
+    }
+  }, done);
+});
+
+test('validateDataAgainstSchema -> syntax error', (t) => {
+  t.plan(2);
+
+  function done (error, result) {
+    t.equal(error.toString(), 'Parse error,\nunexpected token.,\nAt 13 "{......WHOOPS-->.<--.}"');
+    t.notOk(result, 'result was not passed');
+  }
+
+  validateDataAgainstSchema({
+    schema: {
+      firstName: ['{......WHOOPS..}']
+    }
+  }, {
+    headers: {},
+    body: {
+      firstName: 'bob'
+    }
+  }, done);
+});
+
+test('validateDataAgainstSchema -> return validation failure', (t) => {
+  t.plan(2);
+
+  function done (error, result) {
+    t.notOk(result);
+    t.deepEqual(error.friendly.firstName, ['no thanks'], ['validation errors were returned']);
+  }
+
+  validateDataAgainstSchema({
+    schema: {
+      firstName: ['"no thanks"']
+    }
+  }, {
+    headers: {},
+    body: {
+      firstName: 'bob'
+    }
+  }, done);
+});

--- a/test/records/create.js
+++ b/test/records/create.js
@@ -109,41 +109,6 @@ test('only x- headers are allowed', async t => {
   await server.stop();
 });
 
-test('transformations run before schema validations', async t => {
-  t.plan(2);
-  await reset();
-
-  const server = await createServer().start();
-
-  await httpRequest('/v1/databases/test/collections', {
-    method: 'post',
-    data: {
-      name: 'users',
-      schema: {
-        test: ['required', 'string']
-      },
-      transducers: [
-        '{...body test: "text"}'
-      ]
-    }
-  });
-
-  const testInsert = await httpRequest('/v1/databases/test/records/users', {
-    headers: {
-      'x-test-headers': 'test-header-value'
-    },
-    method: 'post',
-    data: {
-      test: 1
-    }
-  });
-
-  t.equal(testInsert.status, 201);
-  t.equal(testInsert.data.test, 'text');
-
-  await server.stop();
-});
-
 test('validation failure -> unknown column', async t => {
   t.plan(2);
   await reset();

--- a/test/records/create.js
+++ b/test/records/create.js
@@ -139,6 +139,32 @@ test('validation failure -> unknown column', async t => {
   await server.stop();
 });
 
+test('create record -> with no schema', async t => {
+  t.plan(2);
+  await reset();
+
+  const server = await createServer().start();
+
+  await httpRequest('/v1/databases/test/collections', {
+    method: 'post',
+    data: {
+      name: 'test'
+    }
+  });
+
+  const testInsert = await httpRequest('/v1/databases/test/records/test', {
+    method: 'post',
+    data: {
+      unknownColumn: 'yes'
+    }
+  });
+
+  t.equal(testInsert.status, 201);
+  t.equal(testInsert.data.unknownColumn, 'yes');
+
+  await server.stop();
+});
+
 test('test inbuild schema field types', async t => {
   t.plan(4);
   await reset();

--- a/test/records/search.js
+++ b/test/records/search.js
@@ -147,35 +147,3 @@ test('list items in collection with custom pagination', async t => {
 
   await server.stop();
 });
-
-test('list items in collection with invalid query', async t => {
-  t.plan(2);
-  await reset();
-
-  const server = await createServer().start();
-
-  await createTestCollection();
-
-  for (let i = 0; i < 100; i++) {
-    await httpRequest('/v1/databases/test/records/test', {
-      method: 'post',
-      data: { test: 'testing' + i }
-    });
-  }
-
-  const query = querystring.stringify({
-    query: JSON.stringify({
-      firstName: 'Joe'
-    })
-  });
-
-  const response = await httpRequest('/v1/databases/test/records/test?' + query, {
-    method: 'get'
-  });
-
-  t.equal(response.status, 400);
-
-  t.deepEqual(response.data, { error: 'query filter on none existing field [firstName]' });
-
-  await server.stop();
-});


### PR DESCRIPTION
Resolves: 
- https://github.com/bitabase/bitabase-server/issues/17
- https://github.com/bitabase/bitabase-server/issues/24

1. This gives us the new syntax as seen in the docs:
https://docs.bitabase.com/docs/api/collections

2. Schema is optional now!

3. Should start reducing transducers, rather the using righto.all

```javascript
fetch('https://api.bitabase.net/v1/databases/test/collections', {
  method: 'post',
  body: {
    name: 'people',

    // Creating and updating items must conform to this schema
    schema: {
      firstName: ['required', 'string'],
      lastName: ['required', 'string'],
      password: ['required', 'string'],
      email: ['required', 'array']
    },

    // These will be run on each record before presenting back to the client
    transducers: [
      '{...body password: hash(body.password)}',
      '{method == "delete" ? reject(401 "you are not allowed to delete people") : body}',
    ],

    // These will be run on each record before presenting back to the client
    presenters: [
      '{...record fullname: concat(record.firstName " " record.lastName)}'
    ]
  },
  headers: {
    'X-Session-Id': 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
    'X-Session-Secret': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
  }
})
```